### PR TITLE
Add option to run on all integration test cases

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,4 @@
+# all commands can be used in either mono or multi node
 
 # to run all tests
 qserv-test-integration.py
@@ -11,10 +12,7 @@ qserv-check-integration.py --case=01 --load --mode=qserv
 # to run integration tests for one case, only for mysql
 qserv-check-integration.py --case=01 --load --mode=mysql
 
-# to run multi-node, use -M
-qserv-check-integration.py --case=01 --load -M --mode=qserv
-
-# if you run a given test previous, you can skipp --load
+# if you ran a given test previously, you can skip --load
 
 # to test individual query, determine proxy port number,
 # e.g., by looking at $QSERV_DIR/var/log/mysql-proxy.log

--- a/python/lsst/qserv/tests/dbLoader.py
+++ b/python/lsst/qserv/tests/dbLoader.py
@@ -56,7 +56,6 @@ class DbLoader(object):
 
             self.nWmgrs = {}
             for node in self.nMgmt.select(nodeType='worker', state='ACTIVE'):
-                self.logger.info("Running on node: %s", node.name())
                 self.nWmgrs[node.name()] = node.wmgrClient()
 
         # This code currently works only with mono-node setup, host

--- a/python/lsst/qserv/tests/qservDbLoader.py
+++ b/python/lsst/qserv/tests/qservDbLoader.py
@@ -113,6 +113,10 @@ class QservLoader(DbLoader):
         loader (qservMeta, emptyChunks file)
         """
 
+        if self.multi_node:
+            for node in self.nWmgrs:
+                self.logger.info("Running on node: %s", node)
+
         self.logger.info("Drop and create MySQL database for Qserv: %s",
                          self._dbName)
 

--- a/python/lsst/qserv/tests/unittest/testIntegration.py
+++ b/python/lsst/qserv/tests/unittest/testIntegration.py
@@ -48,6 +48,8 @@ from lsst.qserv.tests.benchmark import Benchmark
 # -----------------------
 class TestIntegration(unittest.TestCase):
 
+    runMulti = False
+
     @classmethod
     def setUpClass(cls):
         super(TestIntegration, cls).setUpClass()
@@ -72,7 +74,7 @@ class TestIntegration(unittest.TestCase):
     def _runTestCase(self, case_id):
         self.assertTrue(os.path.exists(self.testdata_dir),
                    msg="non existing testdata_dir {0}".format(self.testdata_dir))
-        bench = Benchmark(case_id, False, self.testdata_dir)
+        bench = Benchmark(case_id, self.runMulti, self.testdata_dir)
         bench.run(self.modeList, self.loadData)
         failed_queries = bench.analyzeQueryResults()
         self.assertListEqual(failed_queries, [], msg="Queries in error: {0}".format(failed_queries))
@@ -98,5 +100,6 @@ class TestIntegration(unittest.TestCase):
         self._runTestCase(case_id)
 
 
-def suite():
+def suite(multi_node = False):
+    TestIntegration.runMulti = multi_node
     return unittest.TestLoader().loadTestsFromTestCase(TestIntegration)


### PR DESCRIPTION
Changes to run integration tests in multi-node all together, now they can be run with:

`qserv-test-integration -M`