### PR TITLE
Replace zookeeper CSS with mysql implementation (DM-4003)

### DIFF
--- a/bin/qserv-check-integration.py
+++ b/bin/qserv-check-integration.py
@@ -37,6 +37,7 @@ import ConfigParser
 # ----------------------------
 # Imports for other modules --
 # ----------------------------
+import lsst.log
 from lsst.qserv.admin import commons
 from lsst.qserv.admin import logger
 from lsst.qserv.tests import benchmark
@@ -137,6 +138,13 @@ def _parse_args():
 
     # Configure logger
     logger.setup_logging(args.log_conf)
+
+    # configure log4cxx logging based on the logging level of Python logger
+    levels = {logging.ERROR: lsst.log.ERROR,
+              logging.WARNING: lsst.log.WARN,
+              logging.INFO: lsst.log.INFO,
+              logging.DEBUG: lsst.log.DEBUG}
+    lsst.log.setLevel('', levels.get(_LOG.level, lsst.log.DEBUG))
 
     if args.do_download:
         args.do_custom = True

--- a/bin/qserv-test-integration.py
+++ b/bin/qserv-test-integration.py
@@ -44,6 +44,7 @@ import ConfigParser
 # ----------------------------
 # Imports for other modules --
 # ----------------------------
+import lsst.log
 from lsst.qserv.admin import commons
 from lsst.qserv.admin import logger
 from lsst.qserv.tests.unittest.testIntegration import suite
@@ -76,6 +77,13 @@ if __name__ == '__main__':
 
     args = _parse_args()
     logger.setup_logging(args.log_conf)
+
+    # configure log4cxx logging based on the logging level of Python logger
+    levels = {logging.ERROR: lsst.log.ERROR,
+              logging.WARNING: lsst.log.WARN,
+              logging.INFO: lsst.log.INFO,
+              logging.DEBUG: lsst.log.DEBUG}
+    lsst.log.setLevel('', levels.get(_LOG.level, lsst.log.DEBUG))
 
     config = commons.read_user_config()
     run_dir = config['qserv']['qserv_run_dir']

--- a/python/lsst/qserv/tests/dbLoader.py
+++ b/python/lsst/qserv/tests/dbLoader.py
@@ -51,7 +51,7 @@ class DbLoader(object):
         self.logger = logging.getLogger(__name__)
 
         if self._multi_node:
-            self.qAdmin = qservAdmin.QservAdmin('localhost:' + str(self.config['zookeeper']['port']))
+            self.qAdmin = qservAdmin.QservAdmin(config=self.config['css'])
             self.nMgmt = nodeMgmt.NodeMgmt(self.qAdmin, wmgrSecretFile=self.config['wmgr']['secret'])
 
             self.nWmgrs = {}

--- a/python/lsst/qserv/tests/qservDbLoader.py
+++ b/python/lsst/qserv/tests/qservDbLoader.py
@@ -132,7 +132,7 @@ class QservLoader(DbLoader):
         self.dropCssDatabase()
 
     def dropCssDatabase(self):
-        css = qservAdmin.QservAdmin("localhost:" + str(self.config['zookeeper']['port']))
+        css = qservAdmin.QservAdmin(config=self.config['css'])
         if css.dbExists(self._dbName):
             css.dropDb(self._dbName)
         self.logger.info("Drop CSS database: %s", self._dbName)


### PR DESCRIPTION
Majority of the work is done on a branch in qserv repo, and it needed
few small changes in integration tests:
- connection to CSS service is configured differently now
- need configuration for log4cxx logging in addition to Python log