### PR TITLE
Data loader update after czar+proxy merge (DM-4348)

### DIFF
--- a/python/lsst/qserv/tests/benchmark.py
+++ b/python/lsst/qserv/tests/benchmark.py
@@ -243,7 +243,7 @@ class Benchmark(object):
             # xrootd is restarted by wmgr
 
             # Reload Qserv meta-data
-            commons.restart('qserv-czar')
+            commons.restart('mysql-proxy')
 
             # Hack: Qserv init.d script doesn't check Qserv startup is complete
             time.sleep(2)


### PR DESCRIPTION
Data loader needs to restart czar after updating some structures,
qserv-czar service has disappeared and now we need to restart
mysql-proxy instead.