### PR TITLE
Use better way to reset empty chunks cache (DM-4383)

### DIFF
--- a/python/lsst/qserv/tests/benchmark.py
+++ b/python/lsst/qserv/tests/benchmark.py
@@ -242,11 +242,8 @@ class Benchmark(object):
 
             # xrootd is restarted by wmgr
 
-            # Reload Qserv meta-data
-            commons.restart('mysql-proxy')
-
-            # Hack: Qserv init.d script doesn't check Qserv startup is complete
-            time.sleep(2)
+            # Reload Qserv (empty) chunk cache
+            self.dataLoader['qserv'].resetChunksCache()
 
         # Close socket connections
         del(self.dataLoader[self._mode])

--- a/python/lsst/qserv/tests/dbLoader.py
+++ b/python/lsst/qserv/tests/dbLoader.py
@@ -118,3 +118,9 @@ class DbLoader(object):
         if dataFile:
             cmd += [dataFile]
         return cmd
+
+    def resetChunksCache(self):
+        """
+        Clear czar chunk cache (a.k.a. empty chunk list cache)
+        """
+        self.czar_wmgr.resetChunksCache(self._dbName)


### PR DESCRIPTION
Instead of restarting czar service data loader now uses special wmgr
method to reset chunks cache in czar. This is faster and more efficient.