### PR TITLE
DM-32606: add engine to table schema

### DIFF
--- a/datasets/case01/data/schema/Object.schema
+++ b/datasets/case01/data/schema/Object.schema
@@ -248,7 +248,8 @@ CREATE TABLE `Object` (
   `yRadius_SG` float DEFAULT NULL,
   `yRadius_SG_Sigma` float DEFAULT NULL,
   `yFlags` int(11) DEFAULT NULL,
-  `varBinaryField` varbinary(100) DEFAULT NULL);
+  `varBinaryField` varbinary(100) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;


### PR DESCRIPTION
It was removed from case01 Object.schema a couple years ago, not clear why.
Without it, table creating seems to be failing silently.